### PR TITLE
Move import for deprecated feature

### DIFF
--- a/bin/pssh
+++ b/bin/pssh
@@ -12,7 +12,6 @@ directory.  Each output file in that directory will be named by the
 corresponding remote node's hostname or IP address.
 """
 
-import fcntl
 import os
 import sys
 
@@ -61,6 +60,7 @@ def buffer_input():
 
     Doesn't work if stdin blocks for any reason.  This needs to be deprecated.
     """
+    import fcntl
     fileno = sys.stdin.fileno()
     origfl = fcntl.fcntl(fileno, fcntl.F_GETFL)
     fcntl.fcntl(fileno, fcntl.F_SETFL, origfl | os.O_NONBLOCK)


### PR DESCRIPTION
fcntl not avail on win32, but everything else works fine